### PR TITLE
Fix ticket preview on mobile

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -97,6 +97,8 @@ https://devsleague.com/
           setLoading(STEPS_LOADING.uploading)
           const canvasRecord = await html2canvas(document.querySelector('#ticket'), {
             backgroundColor: '#000000',
+            windowWidth: 1200,
+            windowHeight: 1200,
           })
 
           const dataURL = canvasRecord.toDataURL('image/jpeg', 0.8)


### PR DESCRIPTION
Fixes ticket image preview on mobile by setting fixed window width and height in the generated canvas


before changes:
<img width="200" src="https://github.com/midudev/devsleague.com/assets/98661193/3119f083-988b-41e7-b410-82717b88e904" />

after changes:
<img width="200" src="https://github.com/midudev/devsleague.com/assets/98661193/c3b3ca41-b629-4758-9aea-7ccaed7c436d" />

<img width="200" src="https://github.com/midudev/devsleague.com/assets/98661193/6ed519b7-d07d-461d-8d38-984b10fecd4f" />

